### PR TITLE
[GITHUB-6] Ensures that timesyncd is disabled

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -17,6 +17,12 @@
     state: started
   when: ansible_service_mgr != "systemd"
 
+- name: Ensure timedatectl ntp is off for SystemD
+  become: yes
+  command: timedatectl set-ntp off
+  changed_when: no
+  when: ansible_service_mgr == "systemd"
+
 - name: Ensure NTP is running and enabled for SystemD
   become: yes
   systemd:


### PR DESCRIPTION
Ensures that timesyncd is disable so the NTP service can be fully
enabled.