### PR TITLE
install.yml: remove item iteration due to deprecation warning

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -3,11 +3,10 @@
 - name: Install NTP, tzdata
   become: yes
   apt:
-    name: "{{ item }}"
+    name:
+      - ntp
+      - tzdata
     state: present
-  with_items:
-    - ntp
-    - tzdata
 
 - name: Ensure NTP is running and enabled for SysV
   become: yes


### PR DESCRIPTION
Loop over items with "{{ item }}" will get deprecated in Ansible 2.11.
I changed it to a list of items in `apt: name:`

```bash
TASK [sansible.ntp : Install NTP, tzdata] ****************************************************************************
 [DEPRECATION WARNING]: Invoking "apt" only once while using a loop via squash_actions is deprecated. Instead of using
 a loop to supply multiple items and specifying `name: "{{ item }}"`, please use `name: ['ntp', 'tzdata']` and remove
 the loop. This feature will be removed in version 2.11. Deprecation warnings can be disabled by setting 
deprecation_warnings=False in ansible.cfg.
```